### PR TITLE
Add Airtable sync page

### DIFF
--- a/app/(dashboard)/airtable/layout.tsx
+++ b/app/(dashboard)/airtable/layout.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
+
+export default function AirtableLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <SidebarInset>
+      <header className="bg-background sticky top-0 z-10 flex h-12 shrink-0 items-center gap-2 border-b px-4">
+        <SidebarTrigger className="-ml-1" />
+      </header>
+      <main className="flex-1 p-6">{children}</main>
+    </SidebarInset>
+  );
+}

--- a/app/(dashboard)/airtable/page.tsx
+++ b/app/(dashboard)/airtable/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { SyncsTable } from "@/components/airtable/syncs-table";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { type AirtableSync, fetchSyncs, triggerSync } from "@/lib/airtable/api";
+
+export default function AirtablePage() {
+  const [syncs, setSyncs] = useState<AirtableSync[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [syncing, setSyncing] = useState(false);
+
+  const loadSyncs = useCallback(() => {
+    fetchSyncs()
+      .then(setSyncs)
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load syncs"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    loadSyncs();
+  }, [loadSyncs]);
+
+  async function handleSync() {
+    setSyncing(true);
+    setError("");
+    try {
+      await triggerSync();
+      loadSyncs();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to trigger sync");
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Airtable"
+        description="Sync data from Airtable"
+        action={
+          <Button onClick={handleSync} disabled={syncing}>
+            {syncing ? "Syncing..." : "Sync Now"}
+          </Button>
+        }
+      />
+      {loading && <div className="text-muted-foreground">Loading...</div>}
+      {error && <div className="text-destructive">{error}</div>}
+      {!loading && !error && <SyncsTable syncs={syncs} />}
+    </div>
+  );
+}

--- a/components/airtable/syncs-table.tsx
+++ b/components/airtable/syncs-table.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import type { AirtableSync } from "@/lib/airtable/api";
+
+type SyncsTableProps = {
+  syncs: AirtableSync[];
+};
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleString();
+}
+
+function statusVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
+  switch (status) {
+    case "completed":
+      return "default";
+    case "pending":
+    case "scheduled":
+      return "outline";
+    case "running":
+      return "secondary";
+    case "failed":
+      return "destructive";
+    default:
+      return "outline";
+  }
+}
+
+export function SyncsTable({ syncs }: SyncsTableProps) {
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Status</TableHead>
+            <TableHead>Started At</TableHead>
+            <TableHead>Completed At</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {syncs.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={3} className="text-center text-muted-foreground">
+                No syncs found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            syncs.map((sync) => (
+              <TableRow key={sync.id}>
+                <TableCell>
+                  <Badge variant={statusVariant(sync.status)}>{sync.status}</Badge>
+                </TableCell>
+                <TableCell>{formatTimestamp(sync.started_at)}</TableCell>
+                <TableCell>{formatTimestamp(sync.completed_at)}</TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/components/top-level-sidebar.tsx
+++ b/components/top-level-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Award, LogOut, Zap } from "lucide-react";
+import { Award, LogOut, Table2, Zap } from "lucide-react";
 import Link from "next/link";
 import {
   Sidebar,
@@ -32,6 +32,14 @@ export function TopLevelSidebar({ pathname, logout }: TopLevelSidebarProps) {
               <Link href="/bcorps">
                 <Award />
                 <span>BCorps</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild isActive={pathname.startsWith("/airtable")}>
+              <Link href="/airtable">
+                <Table2 />
+                <span>Airtable</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/lib/airtable/api.ts
+++ b/lib/airtable/api.ts
@@ -1,0 +1,49 @@
+import { getApiUrl } from "@/lib/api/config";
+
+export type AirtableSync = {
+  id: number;
+  status: string;
+  started_at: string | null;
+  completed_at: string | null;
+  stats: Record<string, unknown>;
+  error_message: string | null;
+};
+
+class AirtableApiError extends Error {
+  constructor(
+    public status: number,
+    message?: string
+  ) {
+    super(message ?? `API error ${status}`);
+    this.name = "AirtableApiError";
+  }
+}
+
+async function airtableApi<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(getApiUrl(path), {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...(options?.headers as Record<string, string>)
+    },
+    ...options
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new AirtableApiError(res.status, body.error?.message);
+  }
+  return res.json();
+}
+
+export async function fetchSyncs(): Promise<AirtableSync[]> {
+  const res = await airtableApi<{ airtable_syncs: AirtableSync[] }>("/admin/airtable_syncs");
+  return res.airtable_syncs;
+}
+
+export async function triggerSync(): Promise<AirtableSync> {
+  const res = await airtableApi<{ airtable_sync: AirtableSync }>("/admin/airtable_syncs", {
+    method: "POST"
+  });
+  return res.airtable_sync;
+}


### PR DESCRIPTION
## Summary
- Adds Airtable link to the top-level sidebar with Table2 icon
- New `/airtable` page with "Sync Now" button (POST `/admin/airtable_syncs`)
- Table displaying previous syncs with status, started_at, and completed_at columns
- API client in `lib/airtable/api.ts` hitting the backend endpoints

## Test plan
- [ ] Verify Airtable link appears in sidebar and navigates to `/airtable`
- [ ] Click "Sync Now" and confirm a sync is triggered
- [ ] Verify sync history table loads and displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)