### PR TITLE
Add Downloads admin page

### DIFF
--- a/app/(dashboard)/downloads/layout.tsx
+++ b/app/(dashboard)/downloads/layout.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
+
+export default function DownloadsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <SidebarInset>
+      <header className="bg-background sticky top-0 z-10 flex h-12 shrink-0 items-center gap-2 border-b px-4">
+        <SidebarTrigger className="-ml-1" />
+      </header>
+      <main className="flex-1 p-6">{children}</main>
+    </SidebarInset>
+  );
+}

--- a/app/(dashboard)/downloads/page.tsx
+++ b/app/(dashboard)/downloads/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { DownloadablesTable } from "@/components/downloads/downloadables-table";
+import { PageHeader } from "@/components/page-header";
+import { type Downloadable, fetchDownloadables } from "@/lib/downloads/api";
+
+export default function DownloadsPage() {
+  const [downloadables, setDownloadables] = useState<Downloadable[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = useCallback(() => {
+    fetchDownloadables()
+      .then(setDownloadables)
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load downloadables"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Downloads" description="Manage downloadable resources synced from Airtable" />
+      {loading && <div className="text-muted-foreground">Loading...</div>}
+      {error && <div className="text-destructive">{error}</div>}
+      {!loading && !error && <DownloadablesTable downloadables={downloadables} onChange={load} />}
+    </div>
+  );
+}

--- a/components/downloads/downloadables-table.tsx
+++ b/components/downloads/downloadables-table.tsx
@@ -22,7 +22,7 @@ export function DownloadablesTable({ downloadables, onChange }: DownloadablesTab
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Title</TableHead>
+              <TableHead className="max-w-[300px]">Title</TableHead>
               <TableHead>Enabled</TableHead>
               <TableHead>File</TableHead>
               <TableHead className="text-right">Actions</TableHead>
@@ -38,7 +38,7 @@ export function DownloadablesTable({ downloadables, onChange }: DownloadablesTab
             ) : (
               downloadables.map((downloadable) => (
                 <TableRow key={downloadable.key}>
-                  <TableCell>
+                  <TableCell className="max-w-[300px]">
                     <div className="font-medium">{downloadable.title}</div>
                     {downloadable.description && (
                       <div className="text-xs text-muted-foreground line-clamp-2">{downloadable.description}</div>

--- a/components/downloads/downloadables-table.tsx
+++ b/components/downloads/downloadables-table.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { UploadDialog } from "@/components/downloads/upload-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { type Downloadable, downloadableFileUrl } from "@/lib/downloads/api";
+
+type DownloadablesTableProps = {
+  downloadables: Downloadable[];
+  onChange: () => void;
+};
+
+export function DownloadablesTable({ downloadables, onChange }: DownloadablesTableProps) {
+  const [uploadingKey, setUploadingKey] = useState<string | null>(null);
+  const active = downloadables.find((d) => d.key === uploadingKey) ?? null;
+
+  return (
+    <>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Title</TableHead>
+              <TableHead>Enabled</TableHead>
+              <TableHead>File</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {downloadables.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center text-muted-foreground">
+                  No downloadables found.
+                </TableCell>
+              </TableRow>
+            ) : (
+              downloadables.map((downloadable) => (
+                <TableRow key={downloadable.key}>
+                  <TableCell>
+                    <div className="font-medium">{downloadable.title}</div>
+                    {downloadable.description && (
+                      <div className="text-xs text-muted-foreground line-clamp-2">{downloadable.description}</div>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={downloadable.enabled ? "default" : "outline"}>
+                      {downloadable.enabled ? "Enabled" : "Disabled"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {downloadable.has_file ? (
+                      <a
+                        className="text-sm text-primary underline"
+                        href={downloadableFileUrl(downloadable.key)}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Download
+                      </a>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">No file</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button size="sm" variant="outline" onClick={() => setUploadingKey(downloadable.key)}>
+                      {downloadable.has_file ? "Replace" : "Upload"}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      {active && (
+        <UploadDialog
+          downloadable={active}
+          open={uploadingKey !== null}
+          onOpenChange={(open) => {
+            if (!open) setUploadingKey(null);
+          }}
+          onUploaded={onChange}
+        />
+      )}
+    </>
+  );
+}

--- a/components/downloads/upload-dialog.tsx
+++ b/components/downloads/upload-dialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { type Downloadable, uploadDownloadableFile } from "@/lib/downloads/api";
+
+type UploadDialogProps = {
+  downloadable: Downloadable;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUploaded: () => void;
+};
+
+export function UploadDialog({ downloadable, open, onOpenChange, onUploaded }: UploadDialogProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState("");
+
+  function reset() {
+    setFile(null);
+    setUploading(false);
+    setError("");
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset();
+    onOpenChange(next);
+  }
+
+  async function handleUpload() {
+    if (!file) return;
+    setUploading(true);
+    setError("");
+    try {
+      await uploadDownloadableFile(downloadable.key, file);
+      onUploaded();
+      handleOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Upload file</DialogTitle>
+          <DialogDescription>
+            {downloadable.has_file ? "Replace the file for" : "Attach a file to"} <strong>{downloadable.title}</strong>.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Input
+            ref={inputRef}
+            type="file"
+            accept=".pdf,.docx,.pptx,.xlsx,.png,.jpg,.jpeg,.webp"
+            onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+            disabled={uploading}
+          />
+          <p className="text-xs text-muted-foreground">PDF, DOCX, PPTX, XLSX, PNG, JPEG or WEBP. Max 25 MB.</p>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={uploading}>
+            Cancel
+          </Button>
+          <Button onClick={handleUpload} disabled={!file || uploading}>
+            {uploading ? "Uploading..." : "Upload"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/top-level-sidebar.tsx
+++ b/components/top-level-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Award, LogOut, Table2, Zap } from "lucide-react";
+import { Award, Download, LogOut, Table2, Zap } from "lucide-react";
 import Link from "next/link";
 import {
   Sidebar,
@@ -40,6 +40,14 @@ export function TopLevelSidebar({ pathname, logout }: TopLevelSidebarProps) {
               <Link href="/airtable">
                 <Table2 />
                 <span>Airtable</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild isActive={pathname.startsWith("/downloads")}>
+              <Link href="/downloads">
+                <Download />
+                <span>Downloads</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/lib/downloads/api.ts
+++ b/lib/downloads/api.ts
@@ -1,0 +1,59 @@
+import { getApiUrl } from "@/lib/api/config";
+
+export type Downloadable = {
+  id: number;
+  key: string;
+  title: string;
+  description: string;
+  enabled: boolean;
+  airtable_id: string;
+  has_file: boolean;
+};
+
+class DownloadablesApiError extends Error {
+  constructor(
+    public status: number,
+    message?: string
+  ) {
+    super(message ?? `API error ${status}`);
+    this.name = "DownloadablesApiError";
+  }
+}
+
+async function parseError(res: Response): Promise<DownloadablesApiError> {
+  const body = await res.json().catch(() => ({}));
+  return new DownloadablesApiError(res.status, body.error?.message);
+}
+
+export async function fetchDownloadables(): Promise<Downloadable[]> {
+  const res = await fetch(getApiUrl("/admin/downloadables"), {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json"
+    }
+  });
+  if (!res.ok) throw await parseError(res);
+  const body = (await res.json()) as { downloadables: Downloadable[] };
+  return body.downloadables;
+}
+
+export async function uploadDownloadableFile(key: string, file: File): Promise<Downloadable> {
+  const form = new FormData();
+  form.append("file", file);
+  const res = await fetch(getApiUrl(`/admin/downloadables/${encodeURIComponent(key)}/upload`), {
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      Accept: "application/json"
+    },
+    body: form
+  });
+  if (!res.ok) throw await parseError(res);
+  const body = (await res.json()) as { downloadable: Downloadable };
+  return body.downloadable;
+}
+
+export function downloadableFileUrl(key: string): string {
+  return getApiUrl(`/admin/downloadables/${encodeURIComponent(key)}/file`);
+}


### PR DESCRIPTION
## Summary
- New `/downloads` page listing downloadable resources synced from Airtable
- Per-row Upload/Replace modal that PATCHes the file as multipart to `/admin/downloadables/:key/upload`
- Sidebar entry with Download icon, between Airtable and Facts Engine

Enabled state is shown as a read-only badge (driven by the Airtable sync on the API side — no toggle endpoint). File column links to `GET /admin/downloadables/:key/file` for preview.

## Test plan
- [ ] Visit `/downloads` — page loads, sidebar highlights
- [ ] Rows render with title, enabled badge, file link, and Upload/Replace action
- [ ] Upload dialog accepts pdf/docx/pptx/xlsx/png/jpeg/webp, rejects oversize with backend error surfaced inline
- [ ] After successful upload, dialog closes and table refreshes (file column updates)

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)