### PR TITLE
Add reset questions from seeds button

### DIFF
--- a/app/(dashboard)/(facts-engine)/data/questions/page.tsx
+++ b/app/(dashboard)/(facts-engine)/data/questions/page.tsx
@@ -1,15 +1,30 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { Loader2, Plus, RotateCcw } from "lucide-react";
 import Link from "next/link";
+import { useState } from "react";
+import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
 import { QuestionsThread } from "@/components/questions/questions-thread";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { ApiError, seedQuestions } from "@/lib/blob/api-client";
 import { computeQuestionThread } from "@/lib/blob/derived";
 import { useDataset } from "@/lib/blob/use-dataset";
 
 export default function QuestionsPage() {
   const { blob } = useDataset();
+  const [resetOpen, setResetOpen] = useState(false);
+  const [resetting, setResetting] = useState(false);
 
   if (!blob) return null;
 
@@ -17,20 +32,59 @@ export default function QuestionsPage() {
   const thread = computeQuestionThread(questions);
   const types = [...new Set(questions.map((q) => q.type))];
 
+  async function handleReset(event: React.MouseEvent) {
+    event.preventDefault();
+    setResetting(true);
+    try {
+      await seedQuestions();
+      toast.success("Questions reset from seeds");
+      window.location.reload();
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : "Failed to reset questions";
+      toast.error(message);
+      setResetting(false);
+      setResetOpen(false);
+    }
+  }
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Questions"
         description="Questions presented to users to determine applicable actions."
         action={
-          <Button asChild>
-            <Link href="/data/questions/new">
-              <Plus className="size-4" /> New Question
-            </Link>
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={() => setResetOpen(true)}>
+              <RotateCcw className="size-4" /> Reset Questions from Seeds
+            </Button>
+            <Button asChild>
+              <Link href="/data/questions/new">
+                <Plus className="size-4" /> New Question
+              </Link>
+            </Button>
+          </div>
         }
       />
       <QuestionsThread thread={thread} types={types} totalCount={questions.length} />
+
+      <AlertDialog open={resetOpen} onOpenChange={setResetOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset questions from seeds?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will replace all existing questions with the seed data. Any custom changes to questions will be lost.
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={resetting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" disabled={resetting} onClick={handleReset}>
+              {resetting && <Loader2 className="size-4 animate-spin" />}
+              Reset Questions
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/lib/blob/api-client.ts
+++ b/lib/blob/api-client.ts
@@ -90,6 +90,11 @@ export async function publishDraft(): Promise<Dataset> {
   return unwrapDataset(res);
 }
 
+export async function seedQuestions(): Promise<Dataset> {
+  const res = await api<DatasetResponse>("/admin/facts_datasets/seed_questions", { method: "POST" });
+  return unwrapDataset(res);
+}
+
 // ── Action operations ───────────────────────────────────
 
 type ActionsResponse = { actions: Action[] };


### PR DESCRIPTION
## Summary
- Adds a "Reset Questions from Seeds" button to the Questions admin page (`/data/questions`).
- Posts to `/admin/facts_datasets/seed_questions` after a destructive confirmation modal.
- Reloads the page on success so the dataset state picks up the freshly seeded questions; surfaces API errors via toast.

## Test plan
- [ ] Visit `/data/questions` and confirm the new outline button sits next to "New Question".
- [ ] Click it and confirm the warning modal appears with cancel + destructive confirm buttons.
- [ ] Confirm the dialog and verify the POST hits `/admin/facts_datasets/seed_questions`, a success toast shows, and the page reloads with the seeded questions.
- [ ] Simulate an API failure and confirm the dialog closes with an error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)